### PR TITLE
Update to Agda 2.6.4 and stdlib 2.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -44,6 +44,18 @@ let
   } script;
 
   deps = with pkgs; [
+    (agda.withPackages (p: [
+      (p.standard-library.overrideAttrs (oldAttrs: {
+        version = "2.0";
+        src =  fetchFromGitHub {
+          repo = "agda-stdlib";
+          owner = "agda";
+          rev = "v2.0";
+          hash = "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=";
+        };
+      }))
+    ]))
+
     # For driving the compilation:
     shakefile
 
@@ -52,11 +64,14 @@ let
 
     # For building diagrams:
     poppler_utils our-texlive
+
   ] ++ (if interactive then [
     our-ghc
     sort-imports
+
+    # local preview serving
+    python3
   ] else [
-    (agda.withPackages (p: [ p.standard-library ]))
     labHaskellPackages.pandoc.data
   ]);
 

--- a/default.nix
+++ b/default.nix
@@ -44,17 +44,7 @@ let
   } script;
 
   deps = with pkgs; [
-    (agda.withPackages (p: [
-      (p.standard-library.overrideAttrs (oldAttrs: {
-        version = "2.0";
-        src =  fetchFromGitHub {
-          repo = "agda-stdlib";
-          owner = "agda";
-          rev = "v2.0";
-          hash = "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=";
-        };
-      }))
-    ]))
+    (agda.withPackages (p: [ (p.standard-library) ]))
 
     # For driving the compilation:
     shakefile

--- a/support/nix/agda-packages.nix
+++ b/support/nix/agda-packages.nix
@@ -1,0 +1,13 @@
+final: prev: {
+  agdaPackages = prev.agdaPackages // {
+    standard-library = prev.agdaPackages.standard-library.overrideAttrs (_: {
+      version = "2.0";
+      src = final.fetchFromGitHub {
+        repo = "agda-stdlib";
+        owner = "agda";
+        rev = "v2.0";
+        hash = "sha256-TjGvY3eqpF+DDwatT7A78flyPcTkcLHQ1xcg+MKgCoE=";
+      };
+    });
+  };
+}

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -14,9 +14,9 @@ in
   {
     # Can't just override all Haskell packages because callCabal2nix
     # somehow depends on mime-types
-    labHaskellPackages = super.haskell.packages.ghc946.override (old: {
+    labHaskellPackages = super.haskell.packages.ghc948.override (old: {
       overrides = self: super: {
-        Agda = noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {});
+        # Agda = noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {});
       };
     });
   }

--- a/support/nix/nixpkgs.nix
+++ b/support/nix/nixpkgs.nix
@@ -1,7 +1,11 @@
 args: import (builtins.fetchTarball {
-  name   = "1lab-nixpkgs";
-  url    = "https://github.com/nixos/nixpkgs/archive/6cfbf89825dae72c64188bb218fd4ceca1b6a9e3.tar.gz";
-  sha256 = "sha256:17m78fn3y2x44zgdm428k3l6xamyw6vnz2vd68nj5kxlkbfqnynr";
+  name   = "lab-nixpkgs";
+  # 23.11 as of 24.01
+  url    = "https://github.com/nixos/nixpkgs/archive/6737bac6ac4a5314f34d2c736360a23182c09f17.tar.gz";
+  sha256 = "sha256:1wsjypr389qfxmp9kd0d3sn21vrc0h3j9yk132iwwwksd748b6ln";
 }) ({
-  overlays = [ (import ./haskell-packages.nix) ];
+  overlays = [
+    (import ./agda-packages.nix)
+    (import ./haskell-packages.nix)
+  ];
 } // args)


### PR DESCRIPTION
In order to do so I've set nixpkgs to current realese-23.11 branch. This also included update in ghc used in nixpkgs.

I've also added a python to the shell so it has everything that is needed to run commands in the README.